### PR TITLE
remove @ matching

### DIFF
--- a/lua/explorerc/cnode.lua
+++ b/lua/explorerc/cnode.lua
@@ -33,6 +33,7 @@ M.parse_cnode = function(str, col1, col2, row1, row2)
 
     return parsed_cnode
   else
+    -- handle normal strings without "@" delimiters
     local split_raw_str = utils.split(str, ' ')
     local tag = cnode_tags['generic']
     local tag_desc = ''

--- a/lua/explorerc/cnode_cluster.lua
+++ b/lua/explorerc/cnode_cluster.lua
@@ -18,10 +18,8 @@ M.create_cluster = function(current_bufnr)
   for _, node in query:iter_captures(root, current_bufnr) do
     local text = ts_utils.get_node_text(node, bufnr)[1]
     local row1, col1, row2, col2 = node:range()
-    if string.find(text, '@') then 
-      local parsed_cnode = c.parse_cnode(text, col1, col2, row1, row2)
-      cnodes[#cnodes+1]=parsed_cnode
-    end
+    local parsed_cnode = c.parse_cnode(text, col1, col2, row1, row2)
+    cnodes[#cnodes+1]=parsed_cnode
   end
 
   for index, cnode in pairs(cnodes) do


### PR DESCRIPTION
ExploreRC already provides a default icon and logic to format un "@"ed comments, so all I needed to do was remove the @ matching